### PR TITLE
Task light based fog of war

### DIFF
--- a/Project Pathfinder/Assets/Objects/Prefabs/Character/Chaser.prefab
+++ b/Project Pathfinder/Assets/Objects/Prefabs/Character/Chaser.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 786277952714085039}
   m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
-  m_LocalPosition: {x: -0.46, y: 4.38, z: 0}
+  m_LocalPosition: {x: 0.1, y: -5.9, z: 0}
   m_LocalScale: {x: 7.692307, y: 7.692307, z: 7.692307}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -426,6 +426,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   cameraHolder: {fileID: 1420758059646308807}
+  activeMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  inactiveMaterial: {fileID: 2100000, guid: 6086487f740807a4599e4290220de838, type: 2}
   offset: {x: 0, y: 0, z: 0}
   guardId: 0
   activeGuardId: 0
@@ -458,6 +460,7 @@ MonoBehaviour:
   syncInterval: 0.1
   animator: {fileID: 2696247814498831813}
   damageTaken: 0
+  cameraShake: {fileID: 0}
 --- !u!114 &-4666207054065086445
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Project Pathfinder/Assets/Objects/Prefabs/Character/Chaser.prefab
+++ b/Project Pathfinder/Assets/Objects/Prefabs/Character/Chaser.prefab
@@ -98,7 +98,7 @@ MonoBehaviour:
     m_Center: {x: 0, y: -0.00000011920929, z: 0}
     m_Extent: {x: 0.9985302, y: 0.99853027, z: 0}
   m_PointLightInnerAngle: 0
-  m_PointLightOuterAngle: 75
+  m_PointLightOuterAngle: 90
   m_PointLightInnerRadius: 4
   m_PointLightOuterRadius: 16
   m_ShapeLightParametricSides: 5

--- a/Project Pathfinder/Assets/Objects/Prefabs/Character/Engineer.prefab
+++ b/Project Pathfinder/Assets/Objects/Prefabs/Character/Engineer.prefab
@@ -315,6 +315,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   cameraHolder: {fileID: 1420758059646308807}
+  activeMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  inactiveMaterial: {fileID: 2100000, guid: 6086487f740807a4599e4290220de838, type: 2}
   offset: {x: 0, y: 0, z: 0}
   guardId: 0
   activeGuardId: 0
@@ -347,6 +349,7 @@ MonoBehaviour:
   syncInterval: 0.1
   animator: {fileID: 2696247814498831813}
   damageTaken: 0
+  cameraShake: {fileID: 0}
 --- !u!114 &-597221310296035519
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -387,7 +390,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4426914521127218765}
   m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
-  m_LocalPosition: {x: 0.3, y: -1.6, z: 0}
+  m_LocalPosition: {x: 0.59, y: -6.95, z: 0}
   m_LocalScale: {x: 7.692307, y: 7.692307, z: 7.692307}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Project Pathfinder/Assets/Objects/Prefabs/Character/Runner.prefab
+++ b/Project Pathfinder/Assets/Objects/Prefabs/Character/Runner.prefab
@@ -314,6 +314,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   cameraHolder: {fileID: 1420758059646308807}
+  activeMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  inactiveMaterial: {fileID: 2100000, guid: 6086487f740807a4599e4290220de838, type: 2}
   offset: {x: 0, y: 0, z: 0}
   guardId: 0
   activeGuardId: 0
@@ -386,7 +388,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4258768188753888029}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.49, y: -6, z: 0}
   m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Project Pathfinder/Assets/Objects/Prefabs/Character/Trapper.prefab
+++ b/Project Pathfinder/Assets/Objects/Prefabs/Character/Trapper.prefab
@@ -314,6 +314,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   cameraHolder: {fileID: 1420758059646308807}
+  activeMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  inactiveMaterial: {fileID: 2100000, guid: 6086487f740807a4599e4290220de838, type: 2}
   offset: {x: 0, y: 0, z: 0}
   guardId: 0
   activeGuardId: 0
@@ -346,6 +348,7 @@ MonoBehaviour:
   syncInterval: 0.1
   animator: {fileID: 2696247814498831813}
   damageTaken: 0
+  cameraShake: {fileID: 0}
 --- !u!114 &-3073245883810749708
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -535,7 +538,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8935183616178449606}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0.47, y: -5.33, z: 0}
   m_LocalScale: {x: 7.692307, y: 7.692307, z: 7.692307}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Project Pathfinder/Assets/Scenes/Load Maze.unity
+++ b/Project Pathfinder/Assets/Scenes/Load Maze.unity
@@ -830,6 +830,118 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 656941121}
   m_CullTransparentMesh: 1
+--- !u!1 &665823498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 665823499}
+  - component: {fileID: 665823501}
+  - component: {fileID: 665823500}
+  m_Layer: 0
+  m_Name: Bogey
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &665823499
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 665823498}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.55, y: -1.48, z: -999}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1496269330}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &665823500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 665823498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7db70e0ea77f5ac47a8f4565a9406397, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShadowGroup: 0
+  m_ComponentVersion: 1
+  m_HasRenderer: 1
+  m_UseRendererSilhouette: 1
+  m_CastsShadows: 1
+  m_SelfShadows: 0
+  m_ApplyToSortingLayers: 00000000adaca91eb72b7abb73345817
+  m_ShapePath:
+  - {x: -0.5, y: -0.5, z: 0}
+  - {x: -0.5, y: 0.5, z: 0}
+  - {x: 0.5, y: 0.5, z: 0}
+  - {x: 0.5, y: -0.5, z: 0}
+  m_ShapePathHash: 0
+  m_Mesh: {fileID: 919886781}
+  m_InstanceId: 44394
+--- !u!212 &665823501
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 665823498}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e468a7bceaffa6d4e8b37e5a58e72c3b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &796538987
 GameObject:
   m_ObjectHideFlags: 0
@@ -1188,6 +1300,170 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 878878716}
   m_CullTransparentMesh: 1
+--- !u!43 &919886781
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 0, y: 0, z: 0}
+      m_Extent: {x: 0.5, y: 0.5, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 0000003f000000bf000000000000803f0000008000000080000000800000003f000000bf0000003f000000bf0000003f0000003f00000000000000800000803f00000080000000800000003f0000003f0000003f0000003f0000003f00000000000000000000803f0000008000000080000000800000003f0000003f0000003f000000bf00000000000000bf0000000000000080000080bf00000000000000800000003f000000bf000000bf000000bf000000000000003f00000000000000800000803f0000008000000080000000bf0000003f0000003f0000003f000000bf000000bf0000000000000080000080bf0000000000000080000000bf000000bf000000bf000000bf000000bf0000000000000000000080bf000000800000008000000080000000bf000000bf000000bf0000003f000000bf0000003f00000000000080bf000000800000008000000080000000bf0000003f000000bf0000003f0000003f00000000000000000000803f0000008000000080000000800000003f0000003f0000003f000000bf0000003f000000bf0000000000000080000080bf00000000000000800000003f000000bf0000003f000000bf0000003f0000003f000000000000803f0000008000000080000000800000003f0000003f0000003f0000003f000000000000003f00000000000000800000803f0000008000000080000000bf0000003f0000003f0000003f00000000000000bf0000000000000080000080bf00000000000000800000003f000000bf000000bf000000bf000000bf0000003f00000000000000800000803f0000008000000080000000bf0000003f000000bf0000003f000000bf000000bf00000000000080bf000000800000008000000080000000bf000000bf000000bf000000bf000000bf0000000000000000000080bf000000800000008000000080000000bf000000bf000000bf0000003f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0.5, y: 0.5, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1088118952
 GameObject:
   m_ObjectHideFlags: 0
@@ -1740,7 +2016,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 665823499}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Project Pathfinder/Assets/Scripts/CustomNetworkManager.cs
+++ b/Project Pathfinder/Assets/Scripts/CustomNetworkManager.cs
@@ -187,8 +187,8 @@ public class CustomNetworkManager : NetworkManager
             SetGuardSpawnLocations();
 
             NetworkServer.Spawn(chaser);
-            NetworkServer.Spawn(trapper);
             NetworkServer.Spawn(engineer);
+            NetworkServer.Spawn(trapper);
 
             // Select a random guard to initialize control
             switch (initialActiveGuardId)
@@ -196,14 +196,20 @@ public class CustomNetworkManager : NetworkManager
                 case ManageActiveCharactersConstants.CHASER:
                     NetworkServer.ReplacePlayerForConnection(conn, chaser);
                     initialActiveGuardId = ManageActiveCharactersConstants.CHASER;
+                    chaser.GetComponent<SpriteRenderer>().material
+                       = chaser.GetComponent<ManageActiveCharacters>().activeMaterial;
                     break;
                 case ManageActiveCharactersConstants.ENGINEER:
                     NetworkServer.ReplacePlayerForConnection(conn, engineer);
                     initialActiveGuardId = ManageActiveCharactersConstants.ENGINEER;
+                    engineer.GetComponent<SpriteRenderer>().material
+                       = engineer.GetComponent<ManageActiveCharacters>().activeMaterial;
                     break;
                 case ManageActiveCharactersConstants.TRAPPER:
                     NetworkServer.ReplacePlayerForConnection(conn, trapper);
                     initialActiveGuardId = ManageActiveCharactersConstants.TRAPPER;
+                    trapper.GetComponent<SpriteRenderer>().material
+                       = trapper.GetComponent<ManageActiveCharacters>().activeMaterial;
                     break;
             }
 

--- a/Project Pathfinder/Assets/Scripts/ManageActiveCharacters.cs
+++ b/Project Pathfinder/Assets/Scripts/ManageActiveCharacters.cs
@@ -16,6 +16,8 @@ static class ManageActiveCharactersConstants{
 public class ManageActiveCharacters : NetworkBehaviour
 {
     public GameObject cameraHolder;               // Parent object camera
+    public Material activeMaterial;               // Sprite material for active character (ignores shadows)
+    public Material inactiveMaterial;             // Sprite material for inactive character
     public Vector3 offset;                        // Camera position offset
     public int guardId;                           // Parent object's guard ID
     public int activeGuardId;                     // Guard ID of the current active guard
@@ -129,10 +131,12 @@ public class ManageActiveCharacters : NetworkBehaviour
                 Debug.LogError("newGuardObject is null");
                 break;
         }
-
+        
         // Switch guard control from the old guards object to the next guard's object
         if(newGuardObject != null)
         {
+            newGuardObject.GetComponent<SpriteRenderer>().material = activeMaterial;
+            gameObject.GetComponent<SpriteRenderer>().material = inactiveMaterial;
             NetworkServer.ReplacePlayerForConnection(conn.connectionToClient, newGuardObject);
         }
         else


### PR DESCRIPTION
- Flashlights have been moved to the characters' feet (in the center of their Rigid Body) so that they no longer flash lights through walls.
- The active character's sprite now ignores shadows, so that it's easier to see the sprite of the character you are controlling.
- The chaser's cone of vision is slightly widened.
- Added a bogey square in the Load Maze scene so that the shadow compositor would stop being upset because there were no shadows to composite. The square is in the middle of the maze, but has a low enough Z value (-999) that it should not be at all visible.